### PR TITLE
Security Fix for Prototype Pollution in node-forge

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -55,7 +55,9 @@ forge.debug.set = function(cat, name, data) {
   if(!(cat in forge.debug.storage)) {
     forge.debug.storage[cat] = {};
   }
-  forge.debug.storage[cat][name] = data;
+  if(['__proto__', 'constructor', 'prototype'].indexOf(cat) === -1) {
+    forge.debug.storage[cat][name] = data;
+  }
 };
 
 /**


### PR DESCRIPTION
### 📊 Metadata *

The `node-forge` is found subject to a potential prototype pollution security issue when calling `debug.set` function with unsafe inputs. Despite the `node-forge` has already understood the risk of prototype pollution for the function `util.setPath` and removed it in the latest version 0.10.0 (see https://github.com/digitalbazaar/forge/blob/master/CHANGELOG.md), they still overlooked another risky entry in `debug.set`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-forge/

### ⚙️ Description *

Filter out special properties of `['__proto__', 'constructor', 'prototype']` to be used as the `cat` in `forge.debug.storage`.

### 💻 Technical Description *

if(['__proto__', 'constructor', 'prototype'].indexOf(cat) === -1) {
    forge.debug.storage[cat][name] = data;
 }

### 🐛 Proof of Concept (PoC) *
```
// PoC.js
forge = require('node-forge'); // version at 0.10.0
console.log("Before: " + {}.polluted); // undefined
forge.debug.set('__proto__', 'polluted', 'HACKED');
console.log("After: " + {}.polluted); // HACKED
```

### 🔥 Proof of Fix (PoF) *
```
// PoF.js
forge = require('node-forge'); // version at 0.10.0
console.log("Before: " + {}.polluted); // undefined
forge.debug.set('__proto__', 'polluted', 'HACKED');
console.log("After: " + {}.polluted); // undefined
```

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/834641/111627368-f297bf80-8829-11eb-8fca-3b583d76c808.png)

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-node-forge/
